### PR TITLE
docs: fix separated spelling in docs

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -35,7 +35,7 @@ someIdentifier : {{TypeExpression}}
 ```
 
 An assignment statement is an identifier and a type expression
-    seperated by a `:` symbol.
+    separated by a `:` symbol.
 
 An identifier is a reference to some concrete value in JavaScript.
 
@@ -85,7 +85,7 @@ import { A, B, ... } from "./other-file.jsig"
 ```
 
 An import statement is an `import` keyword followed by a comma
-    seperated list of type names in curly braces, followed by
+    separated list of type names in curly braces, followed by
     a `from` keyword and a file name.
 
 An import statement allows you to import one or more custom


### PR DESCRIPTION
Changes:
- `seperated` -> `separated` in `docs/spec.md` (2 occurrence(s))

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
